### PR TITLE
Disable no-descending-specificity

### DIFF
--- a/.stylelintrc.yml
+++ b/.stylelintrc.yml
@@ -21,6 +21,7 @@ rules:
         - after-comment
   font-family-name-quotes: always-where-recommended
   function-url-quotes: never
+  no-descending-specificity: null
   number-leading-zero: never
   selector-attribute-quotes: always
   selector-type-no-unknown: true


### PR DESCRIPTION
Disabling ` no-descending-specificity` (https://stylelint.io/user-guide/rules/no-descending-specificity/) because sorting selectors according to the actual layout is also _good_:

```css
.header button {}
.footer {}
```