### PR TITLE
Disable font-family-no-missing-generic-family-keyword

### DIFF
--- a/.stylelintrc.yml
+++ b/.stylelintrc.yml
@@ -20,6 +20,7 @@ rules:
       ignore:
         - after-comment
   font-family-name-quotes: always-where-recommended
+  font-family-no-missing-generic-family-keyword: null
   function-url-quotes: never
   no-descending-specificity: null
   number-leading-zero: never


### PR DESCRIPTION
Disabling `font-family-no-missing-generic-family-keyword` (https://stylelint.io/user-guide/rules/font-family-no-missing-generic-family-keyword/) because we are using font icon and there is no fallback for it  👀 